### PR TITLE
Add dependabot check for GitHub action workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Enable version updates for GitHub action workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates to GitHub Actions every weekday
+    schedule:
+      interval: "daily"
+      time: "19:00"
+    open-pull-requests-limit: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,13 @@ jobs:
         go-version: ["1.20", "1.21", "1.22"]
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ matrix.go-version }}
           cache: false
       - name: Checkout code
-        uses: actions/checkout@v4
-      - uses: actions/cache@v4
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
This PR add dependabot check for GitHub action workflows to get pull requests for workflow action updates automatically.
For [security reasons](https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash), it also pins GitHub actions by commit-hash rather than by version. This way of addressing actions plays nicely with dependabot.